### PR TITLE
Update to elm/http 2.0.0 and lukewestby/elm-http-builder 7.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,12 +260,15 @@ You need to have installed following packages:
 "Chadtech/elm-bool-extra": "2.4.0"
 "NoRedInk/elm-json-decode-pipeline": "1.0.0"
 "elm/core": "1.0.2"
-"elm/http": "1.0.0"
+"elm/http": "2.0.0"
 "elm/json": "1.1.3"
 "elm-community/maybe-extra": "5.0.0",
 "elm/url": "1.0.0",
-"lukewestby/elm-http-builder": "6.0.0"
+"elm/bytes": "1.0.8",
+"lukewestby/elm-http-builder": "7.0.0"
 ```
+
+For `elm/http 1.0.0` and `lukewestby/elm-http-builder 6.0.0`, check out version `0.9.1` of this library.
 
 See also example`out/elm.json`.
 

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ incrementPost =
 ##### Http modules
 
 Http module utilizes generated url module and for each endpoint contains
-a function that returns `HttpBuilder.RequestBuilder`.
+a function that returns `HttpBuilder.Task.RequestBuilder`.
 
 ```elm
 {-
@@ -223,31 +223,34 @@ a function that returns `HttpBuilder.RequestBuilder`.
 
 module Request.Counter exposing (currentvalueGet, incrementPost)
 
-import Bool.Extra
-import Data.Counter exposing (..)
-import Data.Increment exposing (..)
-import Dict exposing (Dict)
+import Request.Url.Counter
+import EndpointsElm
 import Http
-import HttpBuilder exposing (RequestBuilder)
+import HttpBuilder.Task exposing (RequestBuilder)
 import Json.Decode as Decode
 import Json.Encode as Encode
+import Bool.Extra
 import Maybe.Extra
-import Request.Url.Counter
+import Bytes exposing (Bytes)
+import Dict exposing (Dict)
+
+import Data.Counter exposing (..)
+import Data.Increment exposing (..)
 
 
-currentvalueGet : RequestBuilder Counter
-currentvalueGet =
-    HttpBuilder.get Request.Url.Counter.currentvalueGet
-        |> HttpBuilder.withExpectJson Data.Counter.decoder
-        |> HttpBuilder.withTimeout 30000
+currentvalueGet : RequestBuilder Http.Error Counter
+currentvalueGet  =
+  HttpBuilder.Task.get (Request.Url.Counter.currentvalueGet )
+    |> HttpBuilder.Task.withResolver (Http.stringResolver (EndpointsElm.httpResolveJson (Data.Counter.decoder)))
+    |> HttpBuilder.Task.withTimeout 30000
 
 
-incrementPost : Increment -> RequestBuilder ()
+incrementPost : Increment -> RequestBuilder Http.Error ()
 incrementPost increment =
-    HttpBuilder.post Request.Url.Counter.incrementPost
-        |> HttpBuilder.withJsonBody (Data.Increment.encoder increment)
-        |> HttpBuilder.withExpect (Http.expectStringResponse (\_ -> Ok ()))
-        |> HttpBuilder.withTimeout 30000
+  HttpBuilder.Task.post (Request.Url.Counter.incrementPost )
+    |> HttpBuilder.Task.withBody (Http.jsonBody (Data.Increment.encoder increment))
+    |> HttpBuilder.Task.withResolver (Http.stringResolver (EndpointsElm.httpResolveUnit))
+    |> HttpBuilder.Task.withTimeout 30000
 ```
 
 ##### Dependencies

--- a/elm-out/elm.json
+++ b/elm-out/elm.json
@@ -10,17 +10,19 @@
             "NoRedInk/elm-json-decode-pipeline": "1.0.0",
             "danyx23/elm-uuid": "2.1.2",
             "elm/browser": "1.0.1",
+            "elm/bytes": "1.0.8",
             "elm/core": "1.0.2",
             "elm/html": "1.0.0",
-            "elm/http": "1.0.0",
+            "elm/http": "2.0.0",
             "elm/json": "1.1.3",
             "elm/random": "1.0.0",
             "elm/url": "1.0.0",
             "elm-community/maybe-extra": "5.0.0",
             "justinmimbs/date": "3.1.2",
-            "lukewestby/elm-http-builder": "6.0.0"
+            "lukewestby/elm-http-builder": "7.0.0"
         },
         "indirect": {
+            "elm/file": "1.0.5",
             "elm/parser": "1.1.0",
             "elm/regex": "1.0.0",
             "elm/time": "1.0.0",

--- a/src/main/resources/elm/EndpointsElm.elm
+++ b/src/main/resources/elm/EndpointsElm.elm
@@ -59,7 +59,7 @@ httpResolve response =
             Err Http.Timeout
 
         Http.NetworkError_ ->
-            Err Http.Timeout
+            Err Http.NetworkError
 
         Http.BadStatus_ metadata _ ->
             Err (Http.BadStatus metadata.statusCode)

--- a/src/main/resources/elm/EndpointsElm.elm
+++ b/src/main/resources/elm/EndpointsElm.elm
@@ -11,7 +11,7 @@ import Http
 import Json.Decode exposing (Decoder)
 
 
-httpResolveNotFound : (Http.Response a -> Result Http.Error a) -> Http.Response a -> Result Http.Error (Maybe a)
+httpResolveNotFound : (Http.Response a -> Result Http.Error b) -> Http.Response a -> Result Http.Error (Maybe b)
 httpResolveNotFound resolveOriginal response =
     case response of
         Http.BadStatus_ metadata _ ->

--- a/src/main/resources/elm/EndpointsElm.elm
+++ b/src/main/resources/elm/EndpointsElm.elm
@@ -1,0 +1,68 @@
+module EndpointsElm exposing
+    ( httpResolveBytes
+    , httpResolveJson
+    , httpResolveNotFound
+    , httpResolveString
+    , httpResolveUnit
+    )
+
+import Bytes exposing (Bytes)
+import Http
+import Json.Decode exposing (Decoder)
+
+
+httpResolveNotFound : (Http.Response a -> Result Http.Error a) -> Http.Response a -> Result Http.Error (Maybe a)
+httpResolveNotFound resolveOriginal response =
+    case response of
+        Http.BadStatus_ metadata _ ->
+            if metadata.statusCode == 404 then
+                Ok Nothing
+
+            else
+                resolveOriginal response |> Result.map Just
+
+        _ ->
+            resolveOriginal response |> Result.map Just
+
+
+httpResolveUnit : Http.Response a -> Result Http.Error ()
+httpResolveUnit =
+    httpResolve >> Result.map (\_ -> ())
+
+
+httpResolveJson : Decoder a -> Http.Response String -> Result Http.Error a
+httpResolveJson decoder =
+    httpResolveString
+        >> Result.andThen
+            (Json.Decode.decodeString decoder
+                >> Result.mapError (Json.Decode.errorToString >> Http.BadBody)
+            )
+
+
+httpResolveString : Http.Response String -> Result Http.Error String
+httpResolveString =
+    httpResolve
+
+
+httpResolveBytes : Http.Response Bytes -> Result Http.Error Bytes
+httpResolveBytes =
+    httpResolve
+
+
+httpResolve : Http.Response a -> Result Http.Error a
+httpResolve response =
+    case response of
+        Http.BadUrl_ url ->
+            Err (Http.BadUrl url)
+
+        Http.Timeout_ ->
+            Err Http.Timeout
+
+        Http.NetworkError_ ->
+            Err Http.Timeout
+
+        Http.BadStatus_ metadata _ ->
+            Err (Http.BadStatus metadata.statusCode)
+
+        Http.GoodStatus_ _ body ->
+            Result.mapError Http.BadBody (Ok body)

--- a/src/main/scala/io/scalaland/endpoints/elm/ElmCodeGenerator.scala
+++ b/src/main/scala/io/scalaland/endpoints/elm/ElmCodeGenerator.scala
@@ -25,9 +25,7 @@ trait ElmCodeGenerator extends Endpoints with JsonSchemaEntities with JsonSchema
   def generateElmContents(endpoints: ElmEndpoint*)(urlPrefix: String = "",
                                                    withCredentials: Boolean = false): Seq[(File, String)] = {
 
-    val commonFiles = Seq(
-      new File("EndpointsElm.elm") -> scala.io.Source.fromResource("elm/EndpointsElm.elm").mkString
-    )
+    val commonFiles = Seq(new File("EndpointsElm.elm") -> scala.io.Source.fromResource("elm/EndpointsElm.elm").mkString)
 
     val typeFiles = captureEndpointsTypes(endpoints).map { elmType =>
       new File(s"Data/${elmType.name}.elm") -> TypeEmit.moduleDefinition(elmType)

--- a/src/main/scala/io/scalaland/endpoints/elm/ElmCodeGenerator.scala
+++ b/src/main/scala/io/scalaland/endpoints/elm/ElmCodeGenerator.scala
@@ -25,6 +25,10 @@ trait ElmCodeGenerator extends Endpoints with JsonSchemaEntities with JsonSchema
   def generateElmContents(endpoints: ElmEndpoint*)(urlPrefix: String = "",
                                                    withCredentials: Boolean = false): Seq[(File, String)] = {
 
+    val commonFiles = Seq(
+      new File("EndpointsElm.elm") -> scala.io.Source.fromResource("elm/EndpointsElm.elm").mkString
+    )
+
     val typeFiles = captureEndpointsTypes(endpoints).map { elmType =>
       new File(s"Data/${elmType.name}.elm") -> TypeEmit.moduleDefinition(elmType)
     }
@@ -39,7 +43,7 @@ trait ElmCodeGenerator extends Endpoints with JsonSchemaEntities with JsonSchema
       new File(s"Request/Url/${httpModule.name}.elm") -> UrlEmit.moduleDefinition(httpModule)(emitCtx)
     }
 
-    typeFiles ++ httpFiles ++ urlFiles
+    commonFiles ++ typeFiles ++ httpFiles ++ urlFiles
   }
 
   private def captureEndpointsTypes(endpoints: Seq[ElmEndpoint]): Seq[ElmType] = {

--- a/src/main/scala/io/scalaland/endpoints/elm/Endpoints.scala
+++ b/src/main/scala/io/scalaland/endpoints/elm/Endpoints.scala
@@ -13,5 +13,5 @@ trait Endpoints extends algebra.Endpoints with Requests with Responses {
                      summary: Documentation = None,
                      description: Documentation = None,
                      tags: List[String] = Nil): Endpoint[A, B] =
-    ElmEndpoint(request.name, request, response._1, response._2, summary, description, tags)
+    ElmEndpoint(request.name, request, response, summary, description, tags)
 }

--- a/src/main/scala/io/scalaland/endpoints/elm/JsonSchemaEntities.scala
+++ b/src/main/scala/io/scalaland/endpoints/elm/JsonSchemaEntities.scala
@@ -7,8 +7,8 @@ import io.scalaland.endpoints.elm.model._
 trait JsonSchemaEntities extends algebra.JsonSchemaEntities with Endpoints with JsonSchemas {
 
   def jsonRequest[A](docs: Documentation = None)(implicit tpe: JsonRequest[A]): RequestEntity[A] =
-    (JsonEncoding, tpe)
+    JsonEncodedType(tpe)
 
   def jsonResponse[A](docs: Documentation = None)(implicit tpe: JsonResponse[A]): Response[A] =
-    (JsonEncoding, tpe)
+    JsonEncodedType(tpe)
 }

--- a/src/main/scala/io/scalaland/endpoints/elm/Requests.scala
+++ b/src/main/scala/io/scalaland/endpoints/elm/Requests.scala
@@ -29,9 +29,7 @@ trait Requests extends algebra.Requests with Urls with Methods {
   type RequestEntity[A] = EncodedType
 
   implicit def reqEntityInvFunctor: InvariantFunctor[RequestEntity] = new InvariantFunctor[RequestEntity] {
-    def xmap[From, To](f: EncodedType,
-                       map: From => To,
-                       contramap: To => From): EncodedType = f
+    def xmap[From, To](f: EncodedType, map: From => To, contramap: To => From): EncodedType = f
   }
 
   def emptyRequest: RequestEntity[Unit] = NoEntityEncodedType

--- a/src/main/scala/io/scalaland/endpoints/elm/Requests.scala
+++ b/src/main/scala/io/scalaland/endpoints/elm/Requests.scala
@@ -26,17 +26,17 @@ trait Requests extends algebra.Requests with Urls with Methods {
     def xmap[From, To](f: List[ElmHeader], map: From => To, contramap: To => From): List[ElmHeader] = f
   }
 
-  type RequestEntity[A] = (ElmEntityEncoding, ElmType)
+  type RequestEntity[A] = EncodedType
 
   implicit def reqEntityInvFunctor: InvariantFunctor[RequestEntity] = new InvariantFunctor[RequestEntity] {
-    def xmap[From, To](f: (ElmEntityEncoding, ElmType),
+    def xmap[From, To](f: EncodedType,
                        map: From => To,
-                       contramap: To => From): (ElmEntityEncoding, ElmType) = f
+                       contramap: To => From): EncodedType = f
   }
 
-  def emptyRequest: RequestEntity[Unit] = (NoEntity, BasicType.Unit)
+  def emptyRequest: RequestEntity[Unit] = NoEntityEncodedType
 
-  def textRequest(docs: Documentation = None): RequestEntity[String] = (StringEncoding, BasicType.String)
+  def textRequest(docs: Documentation = None): RequestEntity[String] = StringEncodedType
 
   type Request[A] = ElmRequest
 
@@ -47,5 +47,5 @@ trait Requests extends algebra.Requests with Urls with Methods {
     headers: RequestHeaders[HeadersP] = emptyHeaders
   )(implicit tuplerUB: Tupler.Aux[UrlP, BodyP, UrlAndBodyPTupled],
     tuplerUBH: Tupler.Aux[UrlAndBodyPTupled, HeadersP, Out]): Request[Out] =
-    ElmRequest(method, url, entity._1, entity._2, headers)
+    ElmRequest(method, url, entity, headers)
 }

--- a/src/main/scala/io/scalaland/endpoints/elm/Responses.scala
+++ b/src/main/scala/io/scalaland/endpoints/elm/Responses.scala
@@ -6,16 +6,18 @@ import io.scalaland.endpoints.elm.model._
 
 trait Responses extends algebra.Responses {
 
-  type Response[A] = (ElmEntityEncoding, ElmType)
+  type Response[A] = EncodedType
 
-  def emptyResponse(docs: Documentation): (ElmEntityEncoding, ElmType) =
-    (NoEntity, BasicType.Unit)
+  def emptyResponse(docs: Documentation): EncodedType =
+    NoEntityEncodedType
 
-  def textResponse(docs: Documentation): (ElmEntityEncoding, ElmType) =
-    (StringEncoding, BasicType.String)
+  def textResponse(docs: Documentation): EncodedType =
+    StringEncodedType
 
-  // TODO: try to model with encoded type so that return type is lifted, as in Scala client interpreters
-  def wheneverFound[A](response: (ElmEntityEncoding, ElmType),
-                       notFoundDocs: Documentation): (ElmEntityEncoding, ElmType) =
-    response
+  def wheneverFound[A](response: EncodedType,
+                       notFoundDocs: Documentation): EncodedType =
+    new WrappedEncodedType(response) {
+      override def tpe: ElmType = AppliedType.Maybe(response.tpe)
+      override def resolveExpr: String = s"EndpointsElm.httpResolveNotFound (${response.resolveExpr})"
+    }
 }

--- a/src/main/scala/io/scalaland/endpoints/elm/Responses.scala
+++ b/src/main/scala/io/scalaland/endpoints/elm/Responses.scala
@@ -14,8 +14,7 @@ trait Responses extends algebra.Responses {
   def textResponse(docs: Documentation): EncodedType =
     StringEncodedType
 
-  def wheneverFound[A](response: EncodedType,
-                       notFoundDocs: Documentation): EncodedType =
+  def wheneverFound[A](response: EncodedType, notFoundDocs: Documentation): EncodedType =
     new WrappedEncodedType(response) {
       override def tpe: ElmType = AppliedType.Maybe(response.tpe)
       override def resolveExpr: String = s"EndpointsElm.httpResolveNotFound (${response.resolveExpr})"

--- a/src/main/scala/io/scalaland/endpoints/elm/Responses.scala
+++ b/src/main/scala/io/scalaland/endpoints/elm/Responses.scala
@@ -14,6 +14,7 @@ trait Responses extends algebra.Responses {
   def textResponse(docs: Documentation): (ElmEntityEncoding, ElmType) =
     (StringEncoding, BasicType.String)
 
+  // TODO: try to model with encoded type so that return type is lifted, as in Scala client interpreters
   def wheneverFound[A](response: (ElmEntityEncoding, ElmType),
                        notFoundDocs: Documentation): (ElmEntityEncoding, ElmType) =
     response

--- a/src/main/scala/io/scalaland/endpoints/elm/emit/HttpEmit.scala
+++ b/src/main/scala/io/scalaland/endpoints/elm/emit/HttpEmit.scala
@@ -56,7 +56,8 @@ object HttpEmit {
       s"""HttpBuilder.Task.withHeader "${header.name}" ${header.normalizedName}"""
     }
 
-    val withCredentialsModifier = if (ctx.withCredentials) List("HttpBuilder.Task.withCredentials") else List.empty[String]
+    val withCredentialsModifier =
+      if (ctx.withCredentials) List("HttpBuilder.Task.withCredentials") else List.empty[String]
 
     val withModifiers =
       withBodyModifier ++
@@ -84,11 +85,7 @@ object HttpEmit {
       case et =>
         val argName = NameUtils.identFromTypeName(et.tpe)
         Some {
-          (
-            argName,
-            ElmType.tpeSignature(et.tpe),
-            s"HttpBuilder.Task.withBody (${et.encodeBody(argName)})"
-          )
+          (argName, ElmType.tpeSignature(et.tpe), s"HttpBuilder.Task.withBody (${et.encodeBody(argName)})")
         }
     }
   }

--- a/src/main/scala/io/scalaland/endpoints/elm/emit/HttpEmit.scala
+++ b/src/main/scala/io/scalaland/endpoints/elm/emit/HttpEmit.scala
@@ -50,6 +50,7 @@ object HttpEmit {
     val argTypesStr = segmentTpes ++ qpTpes ++ bodyTypesStr ++ headerTpes
     val retTpeStr = s"RequestBuilder Http.Error ${TypeEmit.typeReference(endpoint.response, topLevel = false)}"
 
+    // TODO: add some tests to test headers
     val withHeaderModifiers = endpoint.request.headers.map { header =>
       s"""HttpBuilder.Task.withHeader "${header.name}" ${header.normalizedName}"""
     }

--- a/src/main/scala/io/scalaland/endpoints/elm/emit/TypeEmit.scala
+++ b/src/main/scala/io/scalaland/endpoints/elm/emit/TypeEmit.scala
@@ -64,6 +64,7 @@ object TypeEmit {
         case BasicType.Float      => "0.0"
         case BasicType.Bool       => "False"
         case BasicType.Uuid       => "Tuple.first <| step Uuid.uuidGenerator (initialSeed 0)"
+        case BasicType.Bytes      => "{- initial values for Bytes type not supported in endpoints-elm -}"
       }
     case appliedType: AppliedType =>
       appliedType match {
@@ -96,6 +97,7 @@ object TypeEmit {
         case BasicType.Float      => s"Encode.float $arg"
         case BasicType.Bool       => s"Encode.bool $arg"
         case BasicType.Uuid       => s"Uuid.encode $arg"
+        case BasicType.Bytes      => s"{- json encoding for Bytes not supported in endpoints-elm! -}"
       }
     case appliedType: AppliedType =>
       appliedType match {
@@ -158,6 +160,7 @@ object TypeEmit {
         case BasicType.Float      => "Decode.float"
         case BasicType.Bool       => "Decode.bool"
         case BasicType.Uuid       => "Uuid.decoder"
+        case BasicType.Bytes      => s"{- json decoding for Bytes not supported in endpoints-elm! -}"
       }
     case appliedType: AppliedType =>
       val decoder = appliedType match {

--- a/src/main/scala/io/scalaland/endpoints/elm/emit/TypeEmit.scala
+++ b/src/main/scala/io/scalaland/endpoints/elm/emit/TypeEmit.scala
@@ -40,28 +40,18 @@ object TypeEmit {
       s"type alias $name =" + fields
         .map {
           case (nme, tpe) =>
-            s"$nme : ${typeReference(tpe)}"
+            s"$nme : ${ElmType.typeReference(tpe)}"
         }
         .mkString("\n  { ", "\n  , ", "\n  }")
     case UnionType(name, constructors, _) =>
       constructors
         .map {
           case (nme, param) =>
-            s"${unionConstructorName(name, nme)} ${typeReference(param)}"
+            s"${unionConstructorName(name, nme)} ${ElmType.typeReference(param)}"
         }
         .mkString(s"type $name\n  = ", "\n  | ", "")
     case other =>
-      typeReference(other)
-  }
-
-  def typeReference(elmType: ElmType, topLevel: Boolean = true): String = elmType match {
-    case basicType: BasicType => basicType.name
-    case appliedType: AppliedType =>
-      val refStr = s"${appliedType.name} ${appliedType.args.map(typeReference(_, topLevel = false)).mkString(" ")}"
-      if (topLevel) refStr else s"($refStr)"
-    case ReferencedType(name)  => name
-    case TypeAlias(name, _)    => name
-    case UnionType(name, _, _) => name
+      ElmType.typeReference(other)
   }
 
   def initDefinition(elmType: ElmType, topLevel: Boolean = true): String = elmType match {
@@ -258,8 +248,8 @@ object TypeEmit {
     case TypeAlias(_, fields) =>
       fields.toList.flatMap {
         case (fieldName, fieldTpe) =>
-          val tpeRef = typeReference(elmType)
-          val fieldTypeRef = typeReference(fieldTpe)
+          val tpeRef = ElmType.typeReference(elmType)
+          val fieldTypeRef = ElmType.typeReference(fieldTpe)
           val argName = NameUtils.identFromTypeName(elmType)
           List(
             s"set${NameUtils.camelizeName(fieldName)} : $fieldTypeRef -> $tpeRef -> $tpeRef",
@@ -276,8 +266,8 @@ object TypeEmit {
     case TypeAlias(_, fields) =>
       fields.toList.flatMap {
         case (fieldName, fieldTpe) =>
-          val tpeRef = typeReference(elmType)
-          val fieldTypeRef = typeReference(fieldTpe)
+          val tpeRef = ElmType.typeReference(elmType)
+          val fieldTypeRef = ElmType.typeReference(fieldTpe)
           val argName = NameUtils.identFromTypeName(elmType)
           List(
             s"update${NameUtils.camelizeName(fieldName)} : ($fieldTypeRef -> $fieldTypeRef) -> $tpeRef -> $tpeRef",

--- a/src/main/scala/io/scalaland/endpoints/elm/emit/TypeEmit.scala
+++ b/src/main/scala/io/scalaland/endpoints/elm/emit/TypeEmit.scala
@@ -71,6 +71,7 @@ object TypeEmit {
         case AppliedType.Maybe(_) => "Nothing"
         case AppliedType.List(_)  => "[]"
         case AppliedType.Dict(_)  => "Dict.empty"
+        case AppliedType.Result(errTpe, _) => s"Err (${initDefinition(errTpe, topLevel = false)})"
       }
     case ReferencedType(name) => s"Data.$name.init"
     case TypeAlias(_, fields) if topLevel =>
@@ -109,6 +110,8 @@ object TypeEmit {
         case AppliedType.Dict(tpe) =>
           val tpeEncoder = encoderDefinition(tpe, "", topLevel = false)
           s"(Encode.dict identity ($tpeEncoder) $arg)"
+        case AppliedType.Result(_, _) =>
+          "{- json encoding Result type not supported in endpoints-elm! -}"
       }
     case ReferencedType(name) =>
       s"Data.$name.encoder $arg"
@@ -170,6 +173,8 @@ object TypeEmit {
           s"Decode.list ${decoderDefinition(tpe, topLevel = false)}"
         case AppliedType.Dict(tpe) =>
           s"Decode.dict ${decoderDefinition(tpe, topLevel = false)}"
+        case AppliedType.Result(_, _) =>
+          "{- json decoding Result type not supported in endpoints-elm! -}"
       }
       if (topLevel) decoder else s"($decoder)"
     case ReferencedType(name) =>

--- a/src/main/scala/io/scalaland/endpoints/elm/emit/TypeEmit.scala
+++ b/src/main/scala/io/scalaland/endpoints/elm/emit/TypeEmit.scala
@@ -68,9 +68,9 @@ object TypeEmit {
       }
     case appliedType: AppliedType =>
       appliedType match {
-        case AppliedType.Maybe(_) => "Nothing"
-        case AppliedType.List(_)  => "[]"
-        case AppliedType.Dict(_)  => "Dict.empty"
+        case AppliedType.Maybe(_)          => "Nothing"
+        case AppliedType.List(_)           => "[]"
+        case AppliedType.Dict(_)           => "Dict.empty"
         case AppliedType.Result(errTpe, _) => s"Err (${initDefinition(errTpe, topLevel = false)})"
       }
     case ReferencedType(name) => s"Data.$name.init"

--- a/src/main/scala/io/scalaland/endpoints/elm/model/ElmHttp.scala
+++ b/src/main/scala/io/scalaland/endpoints/elm/model/ElmHttp.scala
@@ -56,3 +56,4 @@ sealed trait ElmEntityEncoding
 case object NoEntity extends ElmEntityEncoding
 case object StringEncoding extends ElmEntityEncoding
 case object JsonEncoding extends ElmEntityEncoding
+case class BinaryEncoding(contentType: String) extends ElmEntityEncoding

--- a/src/main/scala/io/scalaland/endpoints/elm/model/ElmHttp.scala
+++ b/src/main/scala/io/scalaland/endpoints/elm/model/ElmHttp.scala
@@ -9,10 +9,7 @@ case class ElmEndpoint(name: String,
                        description: Option[String],
                        tags: List[String])
 
-case class ElmRequest(method: String,
-                      url: ElmUrl,
-                      encodedType: EncodedType,
-                      headers: List[ElmHeader]) {
+case class ElmRequest(method: String, url: ElmUrl, encodedType: EncodedType, headers: List[ElmHeader]) {
 
   def name: String = {
     val urlSegments = url.segments.collect {
@@ -50,13 +47,13 @@ sealed trait ElmHeader {
 case class RequiredHeader(name: String) extends ElmHeader
 case class OptionalHeader(name: String) extends ElmHeader
 
-
 sealed trait EncodedType {
   def tpe: ElmType
   def contentType: String
 
   def resolveExpr: String // elm expr of type: Http.Response respEnc -> Result Http.Error tpe
-  def resolverFunction: String // elm expr of type: (Http.Response respEnc -> Result Http.Error a) -> Http.Resolver Http.Error a
+  def resolverFunction
+    : String // elm expr of type: (Http.Response respEnc -> Result Http.Error a) -> Http.Resolver Http.Error a
   def encodeBody(argName: String): String // elm expr of type Body that may consume argName of type tpe
 }
 
@@ -80,7 +77,8 @@ case class JsonEncodedType(tpe: ElmType) extends EncodedType {
   def contentType: String = "application/json"
   def resolveExpr: String = s"EndpointsElm.httpResolveJson (${TypeEmit.decoderDefinition(tpe, topLevel = false)})"
   def resolverFunction: String = "Http.stringResolver"
-  def encodeBody(argName: String): String = s"""Http.jsonBody (${TypeEmit.encoderDefinition(tpe, argName, topLevel = false)})"""
+  def encodeBody(argName: String): String =
+    s"""Http.jsonBody (${TypeEmit.encoderDefinition(tpe, argName, topLevel = false)})"""
 }
 
 case class BinaryEncodedType(tpe: ElmType = BasicType.Bytes) extends EncodedType {

--- a/src/main/scala/io/scalaland/endpoints/elm/model/ElmHttp.scala
+++ b/src/main/scala/io/scalaland/endpoints/elm/model/ElmHttp.scala
@@ -52,6 +52,12 @@ sealed trait ElmHeader {
 case class RequiredHeader(name: String) extends ElmHeader
 case class OptionalHeader(name: String) extends ElmHeader
 
+
+// TODO: consider alternative: EncodedType; only JsonEncodedType would be parameterized by ElmType
+// TODO: consider also adding ability to plug in own, custom response resolver
+// TODO: encoded type should have resolver assigned; consider in the example of wheneverFound -> by composing resolver we should be able also to lift retuned type to (Maybe X), where X is underlying response type
+
+
 sealed trait ElmEntityEncoding
 case object NoEntity extends ElmEntityEncoding
 case object StringEncoding extends ElmEntityEncoding

--- a/src/main/scala/io/scalaland/endpoints/elm/model/ElmHttp.scala
+++ b/src/main/scala/io/scalaland/endpoints/elm/model/ElmHttp.scala
@@ -52,9 +52,10 @@ sealed trait EncodedType {
   def contentType: String
 
   def resolveExpr: String // elm expr of type: Http.Response respEnc -> Result Http.Error tpe
-  def resolverFunction
-    : String // elm expr of type: (Http.Response respEnc -> Result Http.Error a) -> Http.Resolver Http.Error a
+  def resolverFunction : String // elm expr of type: (Http.Response respEnc -> Result Http.Error a) -> Http.Resolver Http.Error a
   def encodeBody(argName: String): String // elm expr of type Body that may consume argName of type tpe
+
+  def extraImports: Seq[String]
 }
 
 case object NoEntityEncodedType extends EncodedType {
@@ -63,6 +64,7 @@ case object NoEntityEncodedType extends EncodedType {
   def resolveExpr: String = "EndpointsElm.httpResolveUnit"
   def resolverFunction: String = "Http.stringResolver"
   def encodeBody(argName: String): String = s"""Http.stringBody "$contentType" "" """
+  def extraImports: Seq[String] = Seq("EndpointsElm")
 }
 
 case object StringEncodedType extends EncodedType {
@@ -71,6 +73,7 @@ case object StringEncodedType extends EncodedType {
   def resolveExpr: String = s"EndpointsElm.httpResolveString"
   def resolverFunction: String = "Http.stringResolver"
   def encodeBody(argName: String): String = s"""Http.stringBody "$contentType" $argName"""
+  def extraImports: Seq[String] = Seq("EndpointsElm")
 }
 
 case class JsonEncodedType(tpe: ElmType) extends EncodedType {
@@ -79,6 +82,7 @@ case class JsonEncodedType(tpe: ElmType) extends EncodedType {
   def resolverFunction: String = "Http.stringResolver"
   def encodeBody(argName: String): String =
     s"""Http.jsonBody (${TypeEmit.encoderDefinition(tpe, argName, topLevel = false)})"""
+  def extraImports: Seq[String] = Seq("EndpointsElm")
 }
 
 case class BinaryEncodedType(tpe: ElmType = BasicType.Bytes) extends EncodedType {
@@ -86,6 +90,7 @@ case class BinaryEncodedType(tpe: ElmType = BasicType.Bytes) extends EncodedType
   def resolveExpr: String = "EndpointsElm.httpResolveBytes"
   def resolverFunction: String = "Http.bytesResolver"
   def encodeBody(argName: String): String = s"""Http.bytesBody "$contentType" $argName"""
+  def extraImports: Seq[String] = Seq("EndpointsElm")
 }
 
 class WrappedEncodedType(underlying: EncodedType) extends EncodedType {
@@ -94,4 +99,5 @@ class WrappedEncodedType(underlying: EncodedType) extends EncodedType {
   def resolveExpr: String = underlying.resolveExpr
   def resolverFunction: String = underlying.resolverFunction
   def encodeBody(argName: String): String = underlying.encodeBody(argName)
+  def extraImports: Seq[String] = underlying.extraImports
 }

--- a/src/main/scala/io/scalaland/endpoints/elm/model/ElmHttp.scala
+++ b/src/main/scala/io/scalaland/endpoints/elm/model/ElmHttp.scala
@@ -4,16 +4,14 @@ import io.scalaland.endpoints.elm.emit.{NameUtils, TypeEmit}
 
 case class ElmEndpoint(name: String,
                        request: ElmRequest,
-                       responseEncoding: ElmEntityEncoding,
-                       response: ElmType,
+                       encodedType: EncodedType,
                        summary: Option[String],
                        description: Option[String],
                        tags: List[String])
 
 case class ElmRequest(method: String,
                       url: ElmUrl,
-                      encoding: ElmEntityEncoding,
-                      entity: ElmType,
+                      encodedType: EncodedType,
                       headers: List[ElmHeader]) {
 
   def name: String = {
@@ -29,13 +27,13 @@ case class ElmUrl(segments: List[ElmUrlSegment], queryParams: List[(String, ElmT
 
   def segmentTpes: List[(String, String)] = {
     segments.collect {
-      case VariableSegment(nme, tpe) => nme -> TypeEmit.typeReference(tpe, topLevel = false)
+      case VariableSegment(nme, tpe) => nme -> ElmType.typeReference(tpe, topLevel = false)
     }
   }
 
   def queryParamTpes: List[(String, String)] = {
     queryParams.map {
-      case (arg, tpe) => arg -> TypeEmit.typeReference(tpe, topLevel = false)
+      case (arg, tpe) => arg -> ElmType.typeReference(tpe, topLevel = false)
     }
   }
 }
@@ -53,13 +51,49 @@ case class RequiredHeader(name: String) extends ElmHeader
 case class OptionalHeader(name: String) extends ElmHeader
 
 
-// TODO: consider alternative: EncodedType; only JsonEncodedType would be parameterized by ElmType
-// TODO: consider also adding ability to plug in own, custom response resolver
-// TODO: encoded type should have resolver assigned; consider in the example of wheneverFound -> by composing resolver we should be able also to lift retuned type to (Maybe X), where X is underlying response type
+sealed trait EncodedType {
+  def tpe: ElmType
+  def contentType: String
 
+  def resolveExpr: String // elm expr of type: Http.Response respEnc -> Result Http.Error tpe
+  def resolverFunction: String // elm expr of type: (Http.Response respEnc -> Result Http.Error a) -> Http.Resolver Http.Error a
+  def encodeBody(argName: String): String // elm expr of type Body that may consume argName of type tpe
+}
 
-sealed trait ElmEntityEncoding
-case object NoEntity extends ElmEntityEncoding
-case object StringEncoding extends ElmEntityEncoding
-case object JsonEncoding extends ElmEntityEncoding
-case class BinaryEncoding(contentType: String) extends ElmEntityEncoding
+case object NoEntityEncodedType extends EncodedType {
+  def tpe: ElmType = BasicType.Unit
+  def contentType: String = "text/plain"
+  def resolveExpr: String = "EndpointsElm.httpResolveUnit"
+  def resolverFunction: String = "Http.stringResolver"
+  def encodeBody(argName: String): String = s"""Http.stringBody "$contentType" "" """
+}
+
+case object StringEncodedType extends EncodedType {
+  def tpe: ElmType = BasicType.String
+  def contentType: String = "text/plain"
+  def resolveExpr: String = s"EndpointsElm.httpResolveString"
+  def resolverFunction: String = "Http.stringResolver"
+  def encodeBody(argName: String): String = s"""Http.stringBody "$contentType" $argName"""
+}
+
+case class JsonEncodedType(tpe: ElmType) extends EncodedType {
+  def contentType: String = "application/json"
+  def resolveExpr: String = s"EndpointsElm.httpResolveJson (${TypeEmit.decoderDefinition(tpe, topLevel = false)})"
+  def resolverFunction: String = "Http.stringResolver"
+  def encodeBody(argName: String): String = s"""Http.jsonBody (${TypeEmit.encoderDefinition(tpe, argName, topLevel = false)})"""
+}
+
+case class BinaryEncodedType(tpe: ElmType = BasicType.Bytes) extends EncodedType {
+  def contentType: String = "application/octet-stream"
+  def resolveExpr: String = "EndpointsElm.httpResolveBytes"
+  def resolverFunction: String = "Http.bytesResolver"
+  def encodeBody(argName: String): String = s"""Http.bytesBody "$contentType" $argName"""
+}
+
+class WrappedEncodedType(underlying: EncodedType) extends EncodedType {
+  def tpe: ElmType = underlying.tpe
+  def contentType: String = underlying.contentType
+  def resolveExpr: String = underlying.resolveExpr
+  def resolverFunction: String = underlying.resolverFunction
+  def encodeBody(argName: String): String = underlying.encodeBody(argName)
+}

--- a/src/main/scala/io/scalaland/endpoints/elm/model/ElmHttp.scala
+++ b/src/main/scala/io/scalaland/endpoints/elm/model/ElmHttp.scala
@@ -52,7 +52,8 @@ sealed trait EncodedType {
   def contentType: String
 
   def resolveExpr: String // elm expr of type: Http.Response respEnc -> Result Http.Error tpe
-  def resolverFunction : String // elm expr of type: (Http.Response respEnc -> Result Http.Error a) -> Http.Resolver Http.Error a
+  def resolverFunction
+    : String // elm expr of type: (Http.Response respEnc -> Result Http.Error a) -> Http.Resolver Http.Error a
   def encodeBody(argName: String): String // elm expr of type Body that may consume argName of type tpe
 
   def extraImports: Seq[String]

--- a/src/main/scala/io/scalaland/endpoints/elm/model/ElmType.scala
+++ b/src/main/scala/io/scalaland/endpoints/elm/model/ElmType.scala
@@ -32,6 +32,7 @@ object AppliedType {
   case class Maybe(tpe: ElmType) extends AppliedType("Maybe", Seq(tpe))
   case class List(tpe: ElmType) extends AppliedType("List", Seq(tpe))
   case class Dict(tpe: ElmType) extends AppliedType("Dict", Seq(BasicType.String, tpe))
+  case class Result(errTpe: ElmType, okTpe: ElmType) extends AppliedType("Result", Seq(errTpe, okTpe))
 }
 
 case class ReferencedType(name: String) extends ElmType

--- a/src/main/scala/io/scalaland/endpoints/elm/model/ElmType.scala
+++ b/src/main/scala/io/scalaland/endpoints/elm/model/ElmType.scala
@@ -23,6 +23,7 @@ object BasicType {
   object Float extends BasicType("Float")
   object Bool extends BasicType("Bool")
   object Uuid extends BasicType("Uuid")
+  object Bytes extends BasicType("Bytes")
 }
 
 sealed abstract class AppliedType(val name: String, val args: Seq[ElmType]) extends ElmType
@@ -79,4 +80,13 @@ object ElmType {
       Seq(ut)
   }
 
+  def typeReference(elmType: ElmType, topLevel: Boolean = true): String = elmType match {
+    case basicType: BasicType => basicType.name
+    case appliedType: AppliedType =>
+      val refStr = s"${appliedType.name} ${appliedType.args.map(typeReference(_, topLevel = false)).mkString(" ")}"
+      if (topLevel) refStr else s"($refStr)"
+    case ReferencedType(name)  => name
+    case TypeAlias(name, _)    => name
+    case UnionType(name, _, _) => name
+  }
 }

--- a/src/test/resources/counter-test/EndpointsElm.elm
+++ b/src/test/resources/counter-test/EndpointsElm.elm
@@ -59,7 +59,7 @@ httpResolve response =
             Err Http.Timeout
 
         Http.NetworkError_ ->
-            Err Http.Timeout
+            Err Http.NetworkError
 
         Http.BadStatus_ metadata _ ->
             Err (Http.BadStatus metadata.statusCode)

--- a/src/test/resources/counter-test/EndpointsElm.elm
+++ b/src/test/resources/counter-test/EndpointsElm.elm
@@ -1,0 +1,69 @@
+module EndpointsElm exposing
+    ( httpResolveBytes
+    , httpResolveJson
+    , httpResolveNotFound
+    , httpResolveString
+    , httpResolveUnit
+    )
+
+import Bytes exposing (Bytes)
+import Http
+import Json.Decode exposing (Decoder)
+
+
+httpResolveNotFound : (Http.Response a -> Result Http.Error b) -> Http.Response a -> Result Http.Error (Maybe b)
+httpResolveNotFound resolveOriginal response =
+    case response of
+        Http.BadStatus_ metadata _ ->
+            if metadata.statusCode == 404 then
+                Ok Nothing
+
+            else
+                resolveOriginal response |> Result.map Just
+
+        _ ->
+            resolveOriginal response |> Result.map Just
+
+
+httpResolveUnit : Http.Response a -> Result Http.Error ()
+httpResolveUnit =
+    httpResolve >> Result.map (\_ -> ())
+
+
+httpResolveJson : Decoder a -> Http.Response String -> Result Http.Error a
+httpResolveJson decoder =
+    httpResolveString
+        >> Result.andThen
+            (Json.Decode.decodeString decoder
+                >> Result.mapError (Json.Decode.errorToString >> Http.BadBody)
+            )
+
+
+httpResolveString : Http.Response String -> Result Http.Error String
+httpResolveString =
+    httpResolve
+
+
+httpResolveBytes : Http.Response Bytes -> Result Http.Error Bytes
+httpResolveBytes =
+    httpResolve
+
+
+httpResolve : Http.Response a -> Result Http.Error a
+httpResolve response =
+    case response of
+        Http.BadUrl_ url ->
+            Err (Http.BadUrl url)
+
+        Http.Timeout_ ->
+            Err Http.Timeout
+
+        Http.NetworkError_ ->
+            Err Http.Timeout
+
+        Http.BadStatus_ metadata _ ->
+            Err (Http.BadStatus metadata.statusCode)
+
+        Http.GoodStatus_ _ body ->
+            Result.mapError Http.BadBody (Ok body)
+

--- a/src/test/resources/counter-test/Request/Counter.elm
+++ b/src/test/resources/counter-test/Request/Counter.elm
@@ -9,28 +9,30 @@ module Request.Counter exposing (..)
 
 import Request.Url.Counter
 import Http
-import HttpBuilder exposing (RequestBuilder)
+import HttpBuilder.Task exposing (RequestBuilder)
 import Json.Decode as Decode
 import Json.Encode as Encode
 import Bool.Extra
 import Maybe.Extra
+import Bytes exposing (Bytes)
 import Dict exposing (Dict)
 
 import Data.Counter exposing (..)
 import Data.Increment exposing (..)
+import EndpointsElm
 
 
-currentvalueGet : RequestBuilder Counter
+currentvalueGet : RequestBuilder Http.Error Counter
 currentvalueGet  =
-  HttpBuilder.get (Request.Url.Counter.currentvalueGet )
-    |> HttpBuilder.withExpectJson Data.Counter.decoder
-    |> HttpBuilder.withTimeout 30000
+  HttpBuilder.Task.get (Request.Url.Counter.currentvalueGet )
+    |> HttpBuilder.Task.withResolver (Http.stringResolver (EndpointsElm.httpResolveJson (Data.Counter.decoder)))
+    |> HttpBuilder.Task.withTimeout 30000
 
 
-incrementPost : Increment -> RequestBuilder ()
+incrementPost : Increment -> RequestBuilder Http.Error ()
 incrementPost increment =
-  HttpBuilder.post (Request.Url.Counter.incrementPost )
-    |> HttpBuilder.withJsonBody (Data.Increment.encoder  increment)
-    |> HttpBuilder.withExpect (Http.expectStringResponse (\_ -> Ok ()))
-    |> HttpBuilder.withTimeout 30000
+  HttpBuilder.Task.post (Request.Url.Counter.incrementPost )
+    |> HttpBuilder.Task.withBody (Http.jsonBody (Data.Increment.encoder increment))
+    |> HttpBuilder.Task.withResolver (Http.stringResolver (EndpointsElm.httpResolveUnit))
+    |> HttpBuilder.Task.withTimeout 30000
 

--- a/src/test/resources/query-params-test/EndpointsElm.elm
+++ b/src/test/resources/query-params-test/EndpointsElm.elm
@@ -59,7 +59,7 @@ httpResolve response =
             Err Http.Timeout
 
         Http.NetworkError_ ->
-            Err Http.Timeout
+            Err Http.NetworkError
 
         Http.BadStatus_ metadata _ ->
             Err (Http.BadStatus metadata.statusCode)

--- a/src/test/resources/query-params-test/EndpointsElm.elm
+++ b/src/test/resources/query-params-test/EndpointsElm.elm
@@ -1,0 +1,69 @@
+module EndpointsElm exposing
+    ( httpResolveBytes
+    , httpResolveJson
+    , httpResolveNotFound
+    , httpResolveString
+    , httpResolveUnit
+    )
+
+import Bytes exposing (Bytes)
+import Http
+import Json.Decode exposing (Decoder)
+
+
+httpResolveNotFound : (Http.Response a -> Result Http.Error b) -> Http.Response a -> Result Http.Error (Maybe b)
+httpResolveNotFound resolveOriginal response =
+    case response of
+        Http.BadStatus_ metadata _ ->
+            if metadata.statusCode == 404 then
+                Ok Nothing
+
+            else
+                resolveOriginal response |> Result.map Just
+
+        _ ->
+            resolveOriginal response |> Result.map Just
+
+
+httpResolveUnit : Http.Response a -> Result Http.Error ()
+httpResolveUnit =
+    httpResolve >> Result.map (\_ -> ())
+
+
+httpResolveJson : Decoder a -> Http.Response String -> Result Http.Error a
+httpResolveJson decoder =
+    httpResolveString
+        >> Result.andThen
+            (Json.Decode.decodeString decoder
+                >> Result.mapError (Json.Decode.errorToString >> Http.BadBody)
+            )
+
+
+httpResolveString : Http.Response String -> Result Http.Error String
+httpResolveString =
+    httpResolve
+
+
+httpResolveBytes : Http.Response Bytes -> Result Http.Error Bytes
+httpResolveBytes =
+    httpResolve
+
+
+httpResolve : Http.Response a -> Result Http.Error a
+httpResolve response =
+    case response of
+        Http.BadUrl_ url ->
+            Err (Http.BadUrl url)
+
+        Http.Timeout_ ->
+            Err Http.Timeout
+
+        Http.NetworkError_ ->
+            Err Http.Timeout
+
+        Http.BadStatus_ metadata _ ->
+            Err (Http.BadStatus metadata.statusCode)
+
+        Http.GoodStatus_ _ body ->
+            Result.mapError Http.BadBody (Ok body)
+

--- a/src/test/resources/query-params-test/Request/QueryParams.elm
+++ b/src/test/resources/query-params-test/Request/QueryParams.elm
@@ -9,83 +9,85 @@ module Request.QueryParams exposing (..)
 
 import Request.Url.QueryParams
 import Http
-import HttpBuilder exposing (RequestBuilder)
+import HttpBuilder.Task exposing (RequestBuilder)
 import Json.Decode as Decode
 import Json.Encode as Encode
 import Bool.Extra
 import Maybe.Extra
+import Bytes exposing (Bytes)
 import Dict exposing (Dict)
 
 import Date exposing (..)
 import Uuid exposing (..)
+import EndpointsElm
 
 
-stringGet : String -> RequestBuilder ()
+stringGet : String -> RequestBuilder Http.Error ()
 stringGet string =
-  HttpBuilder.get (Request.Url.QueryParams.stringGet string)
-    |> HttpBuilder.withExpect (Http.expectStringResponse (\_ -> Ok ()))
-    |> HttpBuilder.withTimeout 30000
+  HttpBuilder.Task.get (Request.Url.QueryParams.stringGet string)
+    |> HttpBuilder.Task.withResolver (Http.stringResolver (EndpointsElm.httpResolveUnit))
+    |> HttpBuilder.Task.withTimeout 30000
 
 
-intGet : Int -> RequestBuilder ()
+intGet : Int -> RequestBuilder Http.Error ()
 intGet int =
-  HttpBuilder.get (Request.Url.QueryParams.intGet int)
-    |> HttpBuilder.withExpect (Http.expectStringResponse (\_ -> Ok ()))
-    |> HttpBuilder.withTimeout 30000
+  HttpBuilder.Task.get (Request.Url.QueryParams.intGet int)
+    |> HttpBuilder.Task.withResolver (Http.stringResolver (EndpointsElm.httpResolveUnit))
+    |> HttpBuilder.Task.withTimeout 30000
 
 
-longGet : Int -> RequestBuilder ()
+longGet : Int -> RequestBuilder Http.Error ()
 longGet long =
-  HttpBuilder.get (Request.Url.QueryParams.longGet long)
-    |> HttpBuilder.withExpect (Http.expectStringResponse (\_ -> Ok ()))
-    |> HttpBuilder.withTimeout 30000
+  HttpBuilder.Task.get (Request.Url.QueryParams.longGet long)
+    |> HttpBuilder.Task.withResolver (Http.stringResolver (EndpointsElm.httpResolveUnit))
+    |> HttpBuilder.Task.withTimeout 30000
 
 
-doubleGet : Float -> RequestBuilder ()
+doubleGet : Float -> RequestBuilder Http.Error ()
 doubleGet double =
-  HttpBuilder.get (Request.Url.QueryParams.doubleGet double)
-    |> HttpBuilder.withExpect (Http.expectStringResponse (\_ -> Ok ()))
-    |> HttpBuilder.withTimeout 30000
+  HttpBuilder.Task.get (Request.Url.QueryParams.doubleGet double)
+    |> HttpBuilder.Task.withResolver (Http.stringResolver (EndpointsElm.httpResolveUnit))
+    |> HttpBuilder.Task.withTimeout 30000
 
 
-boolGet : Bool -> RequestBuilder ()
+boolGet : Bool -> RequestBuilder Http.Error ()
 boolGet bool =
-  HttpBuilder.get (Request.Url.QueryParams.boolGet bool)
-    |> HttpBuilder.withExpect (Http.expectStringResponse (\_ -> Ok ()))
-    |> HttpBuilder.withTimeout 30000
+  HttpBuilder.Task.get (Request.Url.QueryParams.boolGet bool)
+    |> HttpBuilder.Task.withResolver (Http.stringResolver (EndpointsElm.httpResolveUnit))
+    |> HttpBuilder.Task.withTimeout 30000
 
 
-uuidGet : Uuid -> RequestBuilder ()
+uuidGet : Uuid -> RequestBuilder Http.Error ()
 uuidGet uuid =
-  HttpBuilder.get (Request.Url.QueryParams.uuidGet uuid)
-    |> HttpBuilder.withExpect (Http.expectStringResponse (\_ -> Ok ()))
-    |> HttpBuilder.withTimeout 30000
+  HttpBuilder.Task.get (Request.Url.QueryParams.uuidGet uuid)
+    |> HttpBuilder.Task.withResolver (Http.stringResolver (EndpointsElm.httpResolveUnit))
+    |> HttpBuilder.Task.withTimeout 30000
 
 
-dateGet : Date -> RequestBuilder ()
+dateGet : Date -> RequestBuilder Http.Error ()
 dateGet date =
-  HttpBuilder.get (Request.Url.QueryParams.dateGet date)
-    |> HttpBuilder.withExpect (Http.expectStringResponse (\_ -> Ok ()))
-    |> HttpBuilder.withTimeout 30000
+  HttpBuilder.Task.get (Request.Url.QueryParams.dateGet date)
+    |> HttpBuilder.Task.withResolver (Http.stringResolver (EndpointsElm.httpResolveUnit))
+    |> HttpBuilder.Task.withTimeout 30000
 
 
-listGet : (List Int) -> RequestBuilder ()
+listGet : (List Int) -> RequestBuilder Http.Error ()
 listGet value =
-  HttpBuilder.get (Request.Url.QueryParams.listGet value)
-    |> HttpBuilder.withExpect (Http.expectStringResponse (\_ -> Ok ()))
-    |> HttpBuilder.withTimeout 30000
+  HttpBuilder.Task.get (Request.Url.QueryParams.listGet value)
+    |> HttpBuilder.Task.withResolver (Http.stringResolver (EndpointsElm.httpResolveUnit))
+    |> HttpBuilder.Task.withTimeout 30000
 
 
-optionGet : (Maybe Int) -> RequestBuilder ()
+optionGet : (Maybe Int) -> RequestBuilder Http.Error ()
 optionGet value =
-  HttpBuilder.get (Request.Url.QueryParams.optionGet value)
-    |> HttpBuilder.withExpect (Http.expectStringResponse (\_ -> Ok ()))
-    |> HttpBuilder.withTimeout 30000
+  HttpBuilder.Task.get (Request.Url.QueryParams.optionGet value)
+    |> HttpBuilder.Task.withResolver (Http.stringResolver (EndpointsElm.httpResolveUnit))
+    |> HttpBuilder.Task.withTimeout 30000
 
 
-manyparamsGet : Int -> Float -> RequestBuilder ()
+manyparamsGet : Int -> Float -> RequestBuilder Http.Error ()
 manyparamsGet intValue dblValue =
-  HttpBuilder.get (Request.Url.QueryParams.manyparamsGet intValue dblValue)
-    |> HttpBuilder.withExpect (Http.expectStringResponse (\_ -> Ok ()))
-    |> HttpBuilder.withTimeout 30000
+  HttpBuilder.Task.get (Request.Url.QueryParams.manyparamsGet intValue dblValue)
+    |> HttpBuilder.Task.withResolver (Http.stringResolver (EndpointsElm.httpResolveUnit))
+    |> HttpBuilder.Task.withTimeout 30000
 

--- a/src/test/resources/requests-test/EndpointsElm.elm
+++ b/src/test/resources/requests-test/EndpointsElm.elm
@@ -59,7 +59,7 @@ httpResolve response =
             Err Http.Timeout
 
         Http.NetworkError_ ->
-            Err Http.Timeout
+            Err Http.NetworkError
 
         Http.BadStatus_ metadata _ ->
             Err (Http.BadStatus metadata.statusCode)

--- a/src/test/resources/requests-test/EndpointsElm.elm
+++ b/src/test/resources/requests-test/EndpointsElm.elm
@@ -1,0 +1,69 @@
+module EndpointsElm exposing
+    ( httpResolveBytes
+    , httpResolveJson
+    , httpResolveNotFound
+    , httpResolveString
+    , httpResolveUnit
+    )
+
+import Bytes exposing (Bytes)
+import Http
+import Json.Decode exposing (Decoder)
+
+
+httpResolveNotFound : (Http.Response a -> Result Http.Error b) -> Http.Response a -> Result Http.Error (Maybe b)
+httpResolveNotFound resolveOriginal response =
+    case response of
+        Http.BadStatus_ metadata _ ->
+            if metadata.statusCode == 404 then
+                Ok Nothing
+
+            else
+                resolveOriginal response |> Result.map Just
+
+        _ ->
+            resolveOriginal response |> Result.map Just
+
+
+httpResolveUnit : Http.Response a -> Result Http.Error ()
+httpResolveUnit =
+    httpResolve >> Result.map (\_ -> ())
+
+
+httpResolveJson : Decoder a -> Http.Response String -> Result Http.Error a
+httpResolveJson decoder =
+    httpResolveString
+        >> Result.andThen
+            (Json.Decode.decodeString decoder
+                >> Result.mapError (Json.Decode.errorToString >> Http.BadBody)
+            )
+
+
+httpResolveString : Http.Response String -> Result Http.Error String
+httpResolveString =
+    httpResolve
+
+
+httpResolveBytes : Http.Response Bytes -> Result Http.Error Bytes
+httpResolveBytes =
+    httpResolve
+
+
+httpResolve : Http.Response a -> Result Http.Error a
+httpResolve response =
+    case response of
+        Http.BadUrl_ url ->
+            Err (Http.BadUrl url)
+
+        Http.Timeout_ ->
+            Err Http.Timeout
+
+        Http.NetworkError_ ->
+            Err Http.Timeout
+
+        Http.BadStatus_ metadata _ ->
+            Err (Http.BadStatus metadata.statusCode)
+
+        Http.GoodStatus_ _ body ->
+            Result.mapError Http.BadBody (Ok body)
+

--- a/src/test/resources/requests-test/Request/Requests.elm
+++ b/src/test/resources/requests-test/Request/Requests.elm
@@ -9,111 +9,113 @@ module Request.Requests exposing (..)
 
 import Request.Url.Requests
 import Http
-import HttpBuilder exposing (RequestBuilder)
+import HttpBuilder.Task exposing (RequestBuilder)
 import Json.Decode as Decode
 import Json.Encode as Encode
 import Bool.Extra
 import Maybe.Extra
+import Bytes exposing (Bytes)
 import Dict exposing (Dict)
 
 import Data.Coproduct exposing (..)
 import Data.Foo exposing (..)
 import Date exposing (..)
 import Uuid exposing (..)
+import EndpointsElm
 
 
-jsonstringPost : String -> RequestBuilder ()
+jsonstringPost : String -> RequestBuilder Http.Error ()
 jsonstringPost string =
-  HttpBuilder.post (Request.Url.Requests.jsonstringPost )
-    |> HttpBuilder.withJsonBody (Encode.string  string)
-    |> HttpBuilder.withExpect (Http.expectStringResponse (\_ -> Ok ()))
-    |> HttpBuilder.withTimeout 30000
+  HttpBuilder.Task.post (Request.Url.Requests.jsonstringPost )
+    |> HttpBuilder.Task.withBody (Http.jsonBody (Encode.string string))
+    |> HttpBuilder.Task.withResolver (Http.stringResolver (EndpointsElm.httpResolveUnit))
+    |> HttpBuilder.Task.withTimeout 30000
 
 
-jsonintPost : Int -> RequestBuilder ()
+jsonintPost : Int -> RequestBuilder Http.Error ()
 jsonintPost int =
-  HttpBuilder.post (Request.Url.Requests.jsonintPost )
-    |> HttpBuilder.withJsonBody (Encode.int  int)
-    |> HttpBuilder.withExpect (Http.expectStringResponse (\_ -> Ok ()))
-    |> HttpBuilder.withTimeout 30000
+  HttpBuilder.Task.post (Request.Url.Requests.jsonintPost )
+    |> HttpBuilder.Task.withBody (Http.jsonBody (Encode.int int))
+    |> HttpBuilder.Task.withResolver (Http.stringResolver (EndpointsElm.httpResolveUnit))
+    |> HttpBuilder.Task.withTimeout 30000
 
 
-jsonlongPost : Int -> RequestBuilder ()
+jsonlongPost : Int -> RequestBuilder Http.Error ()
 jsonlongPost int =
-  HttpBuilder.post (Request.Url.Requests.jsonlongPost )
-    |> HttpBuilder.withJsonBody (Encode.int  int)
-    |> HttpBuilder.withExpect (Http.expectStringResponse (\_ -> Ok ()))
-    |> HttpBuilder.withTimeout 30000
+  HttpBuilder.Task.post (Request.Url.Requests.jsonlongPost )
+    |> HttpBuilder.Task.withBody (Http.jsonBody (Encode.int int))
+    |> HttpBuilder.Task.withResolver (Http.stringResolver (EndpointsElm.httpResolveUnit))
+    |> HttpBuilder.Task.withTimeout 30000
 
 
-jsonfloatPost : Float -> RequestBuilder ()
+jsonfloatPost : Float -> RequestBuilder Http.Error ()
 jsonfloatPost float =
-  HttpBuilder.post (Request.Url.Requests.jsonfloatPost )
-    |> HttpBuilder.withJsonBody (Encode.float  float)
-    |> HttpBuilder.withExpect (Http.expectStringResponse (\_ -> Ok ()))
-    |> HttpBuilder.withTimeout 30000
+  HttpBuilder.Task.post (Request.Url.Requests.jsonfloatPost )
+    |> HttpBuilder.Task.withBody (Http.jsonBody (Encode.float float))
+    |> HttpBuilder.Task.withResolver (Http.stringResolver (EndpointsElm.httpResolveUnit))
+    |> HttpBuilder.Task.withTimeout 30000
 
 
-jsondoublePost : Float -> RequestBuilder ()
+jsondoublePost : Float -> RequestBuilder Http.Error ()
 jsondoublePost float =
-  HttpBuilder.post (Request.Url.Requests.jsondoublePost )
-    |> HttpBuilder.withJsonBody (Encode.float  float)
-    |> HttpBuilder.withExpect (Http.expectStringResponse (\_ -> Ok ()))
-    |> HttpBuilder.withTimeout 30000
+  HttpBuilder.Task.post (Request.Url.Requests.jsondoublePost )
+    |> HttpBuilder.Task.withBody (Http.jsonBody (Encode.float float))
+    |> HttpBuilder.Task.withResolver (Http.stringResolver (EndpointsElm.httpResolveUnit))
+    |> HttpBuilder.Task.withTimeout 30000
 
 
-jsonbooleanPost : Bool -> RequestBuilder ()
+jsonbooleanPost : Bool -> RequestBuilder Http.Error ()
 jsonbooleanPost bool =
-  HttpBuilder.post (Request.Url.Requests.jsonbooleanPost )
-    |> HttpBuilder.withJsonBody (Encode.bool  bool)
-    |> HttpBuilder.withExpect (Http.expectStringResponse (\_ -> Ok ()))
-    |> HttpBuilder.withTimeout 30000
+  HttpBuilder.Task.post (Request.Url.Requests.jsonbooleanPost )
+    |> HttpBuilder.Task.withBody (Http.jsonBody (Encode.bool bool))
+    |> HttpBuilder.Task.withResolver (Http.stringResolver (EndpointsElm.httpResolveUnit))
+    |> HttpBuilder.Task.withTimeout 30000
 
 
-jsonuuidPost : Uuid -> RequestBuilder ()
+jsonuuidPost : Uuid -> RequestBuilder Http.Error ()
 jsonuuidPost uuid =
-  HttpBuilder.post (Request.Url.Requests.jsonuuidPost )
-    |> HttpBuilder.withJsonBody (Uuid.encode  uuid)
-    |> HttpBuilder.withExpect (Http.expectStringResponse (\_ -> Ok ()))
-    |> HttpBuilder.withTimeout 30000
+  HttpBuilder.Task.post (Request.Url.Requests.jsonuuidPost )
+    |> HttpBuilder.Task.withBody (Http.jsonBody (Uuid.encode uuid))
+    |> HttpBuilder.Task.withResolver (Http.stringResolver (EndpointsElm.httpResolveUnit))
+    |> HttpBuilder.Task.withTimeout 30000
 
 
-jsondatePost : Date -> RequestBuilder ()
+jsondatePost : Date -> RequestBuilder Http.Error ()
 jsondatePost date =
-  HttpBuilder.post (Request.Url.Requests.jsondatePost )
-    |> HttpBuilder.withJsonBody ((Encode.string << Date.toIsoString)  date)
-    |> HttpBuilder.withExpect (Http.expectStringResponse (\_ -> Ok ()))
-    |> HttpBuilder.withTimeout 30000
+  HttpBuilder.Task.post (Request.Url.Requests.jsondatePost )
+    |> HttpBuilder.Task.withBody (Http.jsonBody ((Encode.string << Date.toIsoString) date))
+    |> HttpBuilder.Task.withResolver (Http.stringResolver (EndpointsElm.httpResolveUnit))
+    |> HttpBuilder.Task.withTimeout 30000
 
 
-jsoncaseclassPost : Foo -> RequestBuilder ()
+jsoncaseclassPost : Foo -> RequestBuilder Http.Error ()
 jsoncaseclassPost foo =
-  HttpBuilder.post (Request.Url.Requests.jsoncaseclassPost )
-    |> HttpBuilder.withJsonBody (Data.Foo.encoder  foo)
-    |> HttpBuilder.withExpect (Http.expectStringResponse (\_ -> Ok ()))
-    |> HttpBuilder.withTimeout 30000
+  HttpBuilder.Task.post (Request.Url.Requests.jsoncaseclassPost )
+    |> HttpBuilder.Task.withBody (Http.jsonBody (Data.Foo.encoder foo))
+    |> HttpBuilder.Task.withResolver (Http.stringResolver (EndpointsElm.httpResolveUnit))
+    |> HttpBuilder.Task.withTimeout 30000
 
 
-jsoncoproductPost : Coproduct -> RequestBuilder ()
+jsoncoproductPost : Coproduct -> RequestBuilder Http.Error ()
 jsoncoproductPost coproduct =
-  HttpBuilder.post (Request.Url.Requests.jsoncoproductPost )
-    |> HttpBuilder.withJsonBody (Data.Coproduct.encoder  coproduct)
-    |> HttpBuilder.withExpect (Http.expectStringResponse (\_ -> Ok ()))
-    |> HttpBuilder.withTimeout 30000
+  HttpBuilder.Task.post (Request.Url.Requests.jsoncoproductPost )
+    |> HttpBuilder.Task.withBody (Http.jsonBody (Data.Coproduct.encoder coproduct))
+    |> HttpBuilder.Task.withResolver (Http.stringResolver (EndpointsElm.httpResolveUnit))
+    |> HttpBuilder.Task.withTimeout 30000
 
 
-jsonlistPost : (List String) -> RequestBuilder ()
+jsonlistPost : (List String) -> RequestBuilder Http.Error ()
 jsonlistPost list =
-  HttpBuilder.post (Request.Url.Requests.jsonlistPost )
-    |> HttpBuilder.withJsonBody ((Encode.list Encode.string )  list)
-    |> HttpBuilder.withExpect (Http.expectStringResponse (\_ -> Ok ()))
-    |> HttpBuilder.withTimeout 30000
+  HttpBuilder.Task.post (Request.Url.Requests.jsonlistPost )
+    |> HttpBuilder.Task.withBody (Http.jsonBody ((Encode.list Encode.string ) list))
+    |> HttpBuilder.Task.withResolver (Http.stringResolver (EndpointsElm.httpResolveUnit))
+    |> HttpBuilder.Task.withTimeout 30000
 
 
-jsonmapPost : (Dict String Foo) -> RequestBuilder ()
+jsonmapPost : (Dict String Foo) -> RequestBuilder Http.Error ()
 jsonmapPost dict =
-  HttpBuilder.post (Request.Url.Requests.jsonmapPost )
-    |> HttpBuilder.withJsonBody ((Encode.dict identity (Data.Foo.encoder ) ) dict)
-    |> HttpBuilder.withExpect (Http.expectStringResponse (\_ -> Ok ()))
-    |> HttpBuilder.withTimeout 30000
+  HttpBuilder.Task.post (Request.Url.Requests.jsonmapPost )
+    |> HttpBuilder.Task.withBody (Http.jsonBody ((Encode.dict identity (Data.Foo.encoder ) dict)))
+    |> HttpBuilder.Task.withResolver (Http.stringResolver (EndpointsElm.httpResolveUnit))
+    |> HttpBuilder.Task.withTimeout 30000
 

--- a/src/test/resources/responses-test/EndpointsElm.elm
+++ b/src/test/resources/responses-test/EndpointsElm.elm
@@ -59,7 +59,7 @@ httpResolve response =
             Err Http.Timeout
 
         Http.NetworkError_ ->
-            Err Http.Timeout
+            Err Http.NetworkError
 
         Http.BadStatus_ metadata _ ->
             Err (Http.BadStatus metadata.statusCode)

--- a/src/test/resources/responses-test/EndpointsElm.elm
+++ b/src/test/resources/responses-test/EndpointsElm.elm
@@ -1,0 +1,69 @@
+module EndpointsElm exposing
+    ( httpResolveBytes
+    , httpResolveJson
+    , httpResolveNotFound
+    , httpResolveString
+    , httpResolveUnit
+    )
+
+import Bytes exposing (Bytes)
+import Http
+import Json.Decode exposing (Decoder)
+
+
+httpResolveNotFound : (Http.Response a -> Result Http.Error b) -> Http.Response a -> Result Http.Error (Maybe b)
+httpResolveNotFound resolveOriginal response =
+    case response of
+        Http.BadStatus_ metadata _ ->
+            if metadata.statusCode == 404 then
+                Ok Nothing
+
+            else
+                resolveOriginal response |> Result.map Just
+
+        _ ->
+            resolveOriginal response |> Result.map Just
+
+
+httpResolveUnit : Http.Response a -> Result Http.Error ()
+httpResolveUnit =
+    httpResolve >> Result.map (\_ -> ())
+
+
+httpResolveJson : Decoder a -> Http.Response String -> Result Http.Error a
+httpResolveJson decoder =
+    httpResolveString
+        >> Result.andThen
+            (Json.Decode.decodeString decoder
+                >> Result.mapError (Json.Decode.errorToString >> Http.BadBody)
+            )
+
+
+httpResolveString : Http.Response String -> Result Http.Error String
+httpResolveString =
+    httpResolve
+
+
+httpResolveBytes : Http.Response Bytes -> Result Http.Error Bytes
+httpResolveBytes =
+    httpResolve
+
+
+httpResolve : Http.Response a -> Result Http.Error a
+httpResolve response =
+    case response of
+        Http.BadUrl_ url ->
+            Err (Http.BadUrl url)
+
+        Http.Timeout_ ->
+            Err Http.Timeout
+
+        Http.NetworkError_ ->
+            Err Http.Timeout
+
+        Http.BadStatus_ metadata _ ->
+            Err (Http.BadStatus metadata.statusCode)
+
+        Http.GoodStatus_ _ body ->
+            Result.mapError Http.BadBody (Ok body)
+

--- a/src/test/resources/responses-test/Request/Responses.elm
+++ b/src/test/resources/responses-test/Request/Responses.elm
@@ -9,99 +9,101 @@ module Request.Responses exposing (..)
 
 import Request.Url.Responses
 import Http
-import HttpBuilder exposing (RequestBuilder)
+import HttpBuilder.Task exposing (RequestBuilder)
 import Json.Decode as Decode
 import Json.Encode as Encode
 import Bool.Extra
 import Maybe.Extra
+import Bytes exposing (Bytes)
 import Dict exposing (Dict)
 
 import Data.Coproduct exposing (..)
 import Data.Foo exposing (..)
 import Date exposing (..)
 import Uuid exposing (..)
+import EndpointsElm
 
 
-jsonstringGet : RequestBuilder String
+jsonstringGet : RequestBuilder Http.Error String
 jsonstringGet  =
-  HttpBuilder.get (Request.Url.Responses.jsonstringGet )
-    |> HttpBuilder.withExpectJson Decode.string
-    |> HttpBuilder.withTimeout 30000
+  HttpBuilder.Task.get (Request.Url.Responses.jsonstringGet )
+    |> HttpBuilder.Task.withResolver (Http.stringResolver (EndpointsElm.httpResolveJson (Decode.string)))
+    |> HttpBuilder.Task.withTimeout 30000
 
 
-jsonintGet : RequestBuilder Int
+jsonintGet : RequestBuilder Http.Error Int
 jsonintGet  =
-  HttpBuilder.get (Request.Url.Responses.jsonintGet )
-    |> HttpBuilder.withExpectJson Decode.int
-    |> HttpBuilder.withTimeout 30000
+  HttpBuilder.Task.get (Request.Url.Responses.jsonintGet )
+    |> HttpBuilder.Task.withResolver (Http.stringResolver (EndpointsElm.httpResolveJson (Decode.int)))
+    |> HttpBuilder.Task.withTimeout 30000
 
 
-jsonlongGet : RequestBuilder Int
+jsonlongGet : RequestBuilder Http.Error Int
 jsonlongGet  =
-  HttpBuilder.get (Request.Url.Responses.jsonlongGet )
-    |> HttpBuilder.withExpectJson Decode.int
-    |> HttpBuilder.withTimeout 30000
+  HttpBuilder.Task.get (Request.Url.Responses.jsonlongGet )
+    |> HttpBuilder.Task.withResolver (Http.stringResolver (EndpointsElm.httpResolveJson (Decode.int)))
+    |> HttpBuilder.Task.withTimeout 30000
 
 
-jsonfloatGet : RequestBuilder Float
+jsonfloatGet : RequestBuilder Http.Error Float
 jsonfloatGet  =
-  HttpBuilder.get (Request.Url.Responses.jsonfloatGet )
-    |> HttpBuilder.withExpectJson Decode.float
-    |> HttpBuilder.withTimeout 30000
+  HttpBuilder.Task.get (Request.Url.Responses.jsonfloatGet )
+    |> HttpBuilder.Task.withResolver (Http.stringResolver (EndpointsElm.httpResolveJson (Decode.float)))
+    |> HttpBuilder.Task.withTimeout 30000
 
 
-jsondoubleGet : RequestBuilder Float
+jsondoubleGet : RequestBuilder Http.Error Float
 jsondoubleGet  =
-  HttpBuilder.get (Request.Url.Responses.jsondoubleGet )
-    |> HttpBuilder.withExpectJson Decode.float
-    |> HttpBuilder.withTimeout 30000
+  HttpBuilder.Task.get (Request.Url.Responses.jsondoubleGet )
+    |> HttpBuilder.Task.withResolver (Http.stringResolver (EndpointsElm.httpResolveJson (Decode.float)))
+    |> HttpBuilder.Task.withTimeout 30000
 
 
-jsonbooleanGet : RequestBuilder Bool
+jsonbooleanGet : RequestBuilder Http.Error Bool
 jsonbooleanGet  =
-  HttpBuilder.get (Request.Url.Responses.jsonbooleanGet )
-    |> HttpBuilder.withExpectJson Decode.bool
-    |> HttpBuilder.withTimeout 30000
+  HttpBuilder.Task.get (Request.Url.Responses.jsonbooleanGet )
+    |> HttpBuilder.Task.withResolver (Http.stringResolver (EndpointsElm.httpResolveJson (Decode.bool)))
+    |> HttpBuilder.Task.withTimeout 30000
 
 
-jsonuuidGet : RequestBuilder Uuid
+jsonuuidGet : RequestBuilder Http.Error Uuid
 jsonuuidGet  =
-  HttpBuilder.get (Request.Url.Responses.jsonuuidGet )
-    |> HttpBuilder.withExpectJson Uuid.decoder
-    |> HttpBuilder.withTimeout 30000
+  HttpBuilder.Task.get (Request.Url.Responses.jsonuuidGet )
+    |> HttpBuilder.Task.withResolver (Http.stringResolver (EndpointsElm.httpResolveJson (Uuid.decoder)))
+    |> HttpBuilder.Task.withTimeout 30000
 
 
-jsondateGet : RequestBuilder Date
+jsondateGet : RequestBuilder Http.Error Date
 jsondateGet  =
-  HttpBuilder.get (Request.Url.Responses.jsondateGet )
-    |> HttpBuilder.withExpectJson (Decode.string |> Decode.andThen (Date.fromIsoString >> Result.map Decode.succeed >> Result.withDefault (Decode.fail "can't parse the date!")))
-    |> HttpBuilder.withTimeout 30000
+  HttpBuilder.Task.get (Request.Url.Responses.jsondateGet )
+    |> HttpBuilder.Task.withResolver (Http.stringResolver (EndpointsElm.httpResolveJson ((Decode.string |> Decode.andThen (Date.fromIsoString >> Result.map Decode.succeed >> Result.withDefault (Decode.fail "can't parse the date!"))))))
+    |> HttpBuilder.Task.withTimeout 30000
 
 
-jsoncaseclassGet : RequestBuilder Foo
+jsoncaseclassGet : RequestBuilder Http.Error Foo
 jsoncaseclassGet  =
-  HttpBuilder.get (Request.Url.Responses.jsoncaseclassGet )
-    |> HttpBuilder.withExpectJson Data.Foo.decoder
-    |> HttpBuilder.withTimeout 30000
+  HttpBuilder.Task.get (Request.Url.Responses.jsoncaseclassGet )
+    |> HttpBuilder.Task.withResolver (Http.stringResolver (EndpointsElm.httpResolveJson (Data.Foo.decoder)))
+    |> HttpBuilder.Task.withTimeout 30000
 
 
-jsoncoproductGet : RequestBuilder Coproduct
+jsoncoproductGet : RequestBuilder Http.Error Coproduct
 jsoncoproductGet  =
-  HttpBuilder.get (Request.Url.Responses.jsoncoproductGet )
-    |> HttpBuilder.withExpectJson Data.Coproduct.decoder
-    |> HttpBuilder.withTimeout 30000
+  HttpBuilder.Task.get (Request.Url.Responses.jsoncoproductGet )
+    |> HttpBuilder.Task.withResolver (Http.stringResolver (EndpointsElm.httpResolveJson (Data.Coproduct.decoder)))
+    |> HttpBuilder.Task.withTimeout 30000
 
 
-jsonlistGet : RequestBuilder (List String)
+jsonlistGet : RequestBuilder Http.Error (List String)
 jsonlistGet  =
-  HttpBuilder.get (Request.Url.Responses.jsonlistGet )
-    |> HttpBuilder.withExpectJson (Decode.list Decode.string)
-    |> HttpBuilder.withTimeout 30000
+  HttpBuilder.Task.get (Request.Url.Responses.jsonlistGet )
+    |> HttpBuilder.Task.withResolver (Http.stringResolver (EndpointsElm.httpResolveJson ((Decode.list Decode.string))))
+    |> HttpBuilder.Task.withTimeout 30000
 
 
-jsonmapGet : RequestBuilder (Dict String Foo)
+jsonmapGet : RequestBuilder Http.Error (Dict String Foo)
 jsonmapGet  =
-  HttpBuilder.get (Request.Url.Responses.jsonmapGet )
-    |> HttpBuilder.withExpectJson (Decode.dict Data.Foo.decoder)
-    |> HttpBuilder.withTimeout 30000
+  HttpBuilder.Task.get (Request.Url.Responses.jsonmapGet )
+    |> HttpBuilder.Task.withResolver (Http.stringResolver (EndpointsElm.httpResolveJson ((Decode.dict Data.Foo.decoder))))
+    |> HttpBuilder.Task.withTimeout 30000
 

--- a/src/test/resources/segments-test/EndpointsElm.elm
+++ b/src/test/resources/segments-test/EndpointsElm.elm
@@ -59,7 +59,7 @@ httpResolve response =
             Err Http.Timeout
 
         Http.NetworkError_ ->
-            Err Http.Timeout
+            Err Http.NetworkError
 
         Http.BadStatus_ metadata _ ->
             Err (Http.BadStatus metadata.statusCode)

--- a/src/test/resources/segments-test/EndpointsElm.elm
+++ b/src/test/resources/segments-test/EndpointsElm.elm
@@ -1,0 +1,69 @@
+module EndpointsElm exposing
+    ( httpResolveBytes
+    , httpResolveJson
+    , httpResolveNotFound
+    , httpResolveString
+    , httpResolveUnit
+    )
+
+import Bytes exposing (Bytes)
+import Http
+import Json.Decode exposing (Decoder)
+
+
+httpResolveNotFound : (Http.Response a -> Result Http.Error b) -> Http.Response a -> Result Http.Error (Maybe b)
+httpResolveNotFound resolveOriginal response =
+    case response of
+        Http.BadStatus_ metadata _ ->
+            if metadata.statusCode == 404 then
+                Ok Nothing
+
+            else
+                resolveOriginal response |> Result.map Just
+
+        _ ->
+            resolveOriginal response |> Result.map Just
+
+
+httpResolveUnit : Http.Response a -> Result Http.Error ()
+httpResolveUnit =
+    httpResolve >> Result.map (\_ -> ())
+
+
+httpResolveJson : Decoder a -> Http.Response String -> Result Http.Error a
+httpResolveJson decoder =
+    httpResolveString
+        >> Result.andThen
+            (Json.Decode.decodeString decoder
+                >> Result.mapError (Json.Decode.errorToString >> Http.BadBody)
+            )
+
+
+httpResolveString : Http.Response String -> Result Http.Error String
+httpResolveString =
+    httpResolve
+
+
+httpResolveBytes : Http.Response Bytes -> Result Http.Error Bytes
+httpResolveBytes =
+    httpResolve
+
+
+httpResolve : Http.Response a -> Result Http.Error a
+httpResolve response =
+    case response of
+        Http.BadUrl_ url ->
+            Err (Http.BadUrl url)
+
+        Http.Timeout_ ->
+            Err Http.Timeout
+
+        Http.NetworkError_ ->
+            Err Http.Timeout
+
+        Http.BadStatus_ metadata _ ->
+            Err (Http.BadStatus metadata.statusCode)
+
+        Http.GoodStatus_ _ body ->
+            Result.mapError Http.BadBody (Ok body)
+

--- a/src/test/resources/segments-test/Request/Segments.elm
+++ b/src/test/resources/segments-test/Request/Segments.elm
@@ -9,48 +9,50 @@ module Request.Segments exposing (..)
 
 import Request.Url.Segments
 import Http
-import HttpBuilder exposing (RequestBuilder)
+import HttpBuilder.Task exposing (RequestBuilder)
 import Json.Decode as Decode
 import Json.Encode as Encode
 import Bool.Extra
 import Maybe.Extra
+import Bytes exposing (Bytes)
 import Dict exposing (Dict)
 
 import Date exposing (..)
 import Uuid exposing (..)
+import EndpointsElm
 
 
-stringStringGet : String -> RequestBuilder ()
+stringStringGet : String -> RequestBuilder Http.Error ()
 stringStringGet string =
-  HttpBuilder.get (Request.Url.Segments.stringStringGet string)
-    |> HttpBuilder.withExpect (Http.expectStringResponse (\_ -> Ok ()))
-    |> HttpBuilder.withTimeout 30000
+  HttpBuilder.Task.get (Request.Url.Segments.stringStringGet string)
+    |> HttpBuilder.Task.withResolver (Http.stringResolver (EndpointsElm.httpResolveUnit))
+    |> HttpBuilder.Task.withTimeout 30000
 
 
-intIntGet : Int -> RequestBuilder ()
+intIntGet : Int -> RequestBuilder Http.Error ()
 intIntGet int =
-  HttpBuilder.get (Request.Url.Segments.intIntGet int)
-    |> HttpBuilder.withExpect (Http.expectStringResponse (\_ -> Ok ()))
-    |> HttpBuilder.withTimeout 30000
+  HttpBuilder.Task.get (Request.Url.Segments.intIntGet int)
+    |> HttpBuilder.Task.withResolver (Http.stringResolver (EndpointsElm.httpResolveUnit))
+    |> HttpBuilder.Task.withTimeout 30000
 
 
-longLongGet : Int -> RequestBuilder ()
+longLongGet : Int -> RequestBuilder Http.Error ()
 longLongGet long =
-  HttpBuilder.get (Request.Url.Segments.longLongGet long)
-    |> HttpBuilder.withExpect (Http.expectStringResponse (\_ -> Ok ()))
-    |> HttpBuilder.withTimeout 30000
+  HttpBuilder.Task.get (Request.Url.Segments.longLongGet long)
+    |> HttpBuilder.Task.withResolver (Http.stringResolver (EndpointsElm.httpResolveUnit))
+    |> HttpBuilder.Task.withTimeout 30000
 
 
-uuidUuidGet : Uuid -> RequestBuilder ()
+uuidUuidGet : Uuid -> RequestBuilder Http.Error ()
 uuidUuidGet uuid =
-  HttpBuilder.get (Request.Url.Segments.uuidUuidGet uuid)
-    |> HttpBuilder.withExpect (Http.expectStringResponse (\_ -> Ok ()))
-    |> HttpBuilder.withTimeout 30000
+  HttpBuilder.Task.get (Request.Url.Segments.uuidUuidGet uuid)
+    |> HttpBuilder.Task.withResolver (Http.stringResolver (EndpointsElm.httpResolveUnit))
+    |> HttpBuilder.Task.withTimeout 30000
 
 
-dateDateGet : Date -> RequestBuilder ()
+dateDateGet : Date -> RequestBuilder Http.Error ()
 dateDateGet date =
-  HttpBuilder.get (Request.Url.Segments.dateDateGet date)
-    |> HttpBuilder.withExpect (Http.expectStringResponse (\_ -> Ok ()))
-    |> HttpBuilder.withTimeout 30000
+  HttpBuilder.Task.get (Request.Url.Segments.dateDateGet date)
+    |> HttpBuilder.Task.withResolver (Http.stringResolver (EndpointsElm.httpResolveUnit))
+    |> HttpBuilder.Task.withTimeout 30000
 

--- a/src/test/scala/io/scalaland/endpoints/elm/CounterTest.scala
+++ b/src/test/scala/io/scalaland/endpoints/elm/CounterTest.scala
@@ -47,7 +47,10 @@ object CounterTest extends CodegenTest {
 
     "generate code for simple domain model" - {
 
+//      writeElmCode("src/test/resources/counter-test")(allEndpoints: _*)()
+
       generateElmContents(allEndpoints: _*)() sameAs ReferenceData.from("counter-test")(
+        "EndpointsElm.elm",
         "Data/Counter.elm",
         "Data/Increment.elm",
         "Request/Url/Counter.elm",

--- a/src/test/scala/io/scalaland/endpoints/elm/QueryParamsTest.scala
+++ b/src/test/scala/io/scalaland/endpoints/elm/QueryParamsTest.scala
@@ -74,7 +74,10 @@ object QueryParamsTest extends CodegenTest {
 
     "support query parameters" - {
 
+//      writeElmCode("src/test/resources/query-params-test")(allEndpoints: _*)()
+
       generateElmContents(allEndpoints: _*)() sameAs ReferenceData.from("query-params-test")(
+        "EndpointsElm.elm",
         "Request/Url/QueryParams.elm",
         "Request/QueryParams.elm"
       )

--- a/src/test/scala/io/scalaland/endpoints/elm/RequestsTest.scala
+++ b/src/test/scala/io/scalaland/endpoints/elm/RequestsTest.scala
@@ -78,7 +78,10 @@ object RequestsTest extends CodegenTest {
 
     "support requests" - {
 
+//      writeElmCode("src/test/resources/requests-test")(allEndpoints: _*)()
+
       generateElmContents(allEndpoints: _*)() sameAs ReferenceData.from("requests-test")(
+        "EndpointsElm.elm",
         "Data/Coproduct.elm",
         "Data/Foo.elm",
         "Data/Inst1.elm",

--- a/src/test/scala/io/scalaland/endpoints/elm/ResponsesTest.scala
+++ b/src/test/scala/io/scalaland/endpoints/elm/ResponsesTest.scala
@@ -78,7 +78,10 @@ object ResponsesTest extends CodegenTest {
 
     "support Responses" - {
 
+//      writeElmCode("src/test/resources/responses-test")(allEndpoints: _*)()
+
       generateElmContents(allEndpoints: _*)() sameAs ReferenceData.from("responses-test")(
+        "EndpointsElm.elm",
         "Data/Coproduct.elm",
         "Data/Foo.elm",
         "Data/Inst1.elm",

--- a/src/test/scala/io/scalaland/endpoints/elm/SegmentsTest.scala
+++ b/src/test/scala/io/scalaland/endpoints/elm/SegmentsTest.scala
@@ -42,7 +42,10 @@ object SegmentsTest extends CodegenTest {
 
     "support segments" - {
 
+//      writeElmCode("src/test/resources/segments-test")(allEndpoints: _*)()
+
       generateElmContents(allEndpoints: _*)() sameAs ReferenceData.from("segments-test")(
+        "EndpointsElm.elm",
         "Request/Url/Segments.elm",
         "Request/Segments.elm"
       )


### PR DESCRIPTION
This PR addresses #5 

Due to serious changes in elm/http, I had to change intermediate model of type encoding. Hopefully, thanks to this change, in the elm algebra interpreter we have more control given about encoding request bodies and lifting http responses to proper types in elm world.